### PR TITLE
Hide studio owner only links

### DIFF
--- a/app/controllers/availabilities_controller.rb
+++ b/app/controllers/availabilities_controller.rb
@@ -47,7 +47,7 @@ class AvailabilitiesController < ApplicationController
     end
     @bookings = @studio.bookings.select{ |av| av.end_time >= DateTime.now-7 }
     @bookings.each do |booking|
-      availabilities << { :color => 'red', :title => "Booked", :start => "#{booking.start_time.iso8601}", :end => "#{booking.start_time.iso8601}", :description => "This slot is currently booked by #{booking.user.first_name} #{booking.user.last_name}, who booked #{booking.user.bookings.count} studios in the past with an average rating of #{booking.user.average_rating}. You can contact your renter at #{booking.user.email}." , :allDay => false, :overlap => false}
+      availabilities << { :color => 'red', :title => "Booked", :start => "#{booking.start_time.iso8601}", :end => "#{booking.end_time.iso8601}", :description => "This slot is currently booked by #{booking.user.first_name} #{booking.user.last_name}, who booked #{booking.user.bookings.count} studios in the past with an average rating of #{booking.user.average_rating}. You can contact your renter at #{booking.user.email}." , :allDay => false, :overlap => false}
     end
     render :text => availabilities.to_json
   end

--- a/app/controllers/availabilities_controller.rb
+++ b/app/controllers/availabilities_controller.rb
@@ -2,12 +2,33 @@ class AvailabilitiesController < ApplicationController
   skip_before_filter :verify_authenticity_token
   before_action :logged_in_user, except: [:index, :get_availabilities]
 
+
+  def redirect_if_not_owner
+    if is_studio_owner?
+      puts is_studio_owner?
+      return true
+    else
+      redirect_to root_path
+    end
+  end
+
+  def is_studio_owner?
+    current_user == Studio.find_by(id: session[:studio_id]).owner
+  end
+
   def index
     @studio = Studio.find_by(id: params[:studio_id])
     if @studio
       session[:studio_id] = @studio.id
+      if is_studio_owner?
+        true
+      else
+        flash[:danger] = ["Only studio owners can edit availabilities"]
+        puts flash[:danger]
+        redirect_to root_path
+      end
     else
-      flash[:notice] = "That studio does not exist"
+      flash[:danger] = ["That studio does not exist"]
       redirect_to root_path
     end
   end

--- a/app/controllers/bookings_controller.rb
+++ b/app/controllers/bookings_controller.rb
@@ -6,7 +6,7 @@ class BookingsController < ApplicationController
     @studio = Studio.find_by(id: params[:studio_id])
 
     concat_start = "#{params[:start_date]} #{params[:s_time]}"
-    concat_end = "#{params[:end_date]} #{params[:e_time]}"
+    concat_end = "#{params[:start_date]} #{params[:e_time]}"
 
     requested_start_time = Booking.convert_to_datetime(concat_start)
     requested_end_time = Booking.convert_to_datetime(concat_end)

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -11,4 +11,8 @@ module UsersHelper
   	session[:user_id] = params[:id] ? true : false
   end
 
+  def is_studio_owner?
+    current_user == Studio.find_by_id(id: session[:studio_id]).owner
+  end
+
 end

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -12,7 +12,7 @@ module UsersHelper
   end
 
   def is_studio_owner?
-    current_user == Studio.find_by_id(id: session[:studio_id]).owner
+    current_user == Studio.find_by(id: session[:studio_id]).owner
   end
 
 end

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -15,4 +15,6 @@ module UsersHelper
     current_user == Studio.find_by(id: session[:studio_id]).owner
   end
 
+
+
 end

--- a/app/models/studio.rb
+++ b/app/models/studio.rb
@@ -33,7 +33,7 @@ class Studio < ActiveRecord::Base
     all_unbooked_times = availabilities.map do |availability|
       availability.unbooked_times.map{ |array_of_times| array_of_times << availability.id}
     end
-    all_unbooked_times.flatten(1)
+    all_unbooked_times.flatten(1).select{ |start_and_end_array| start_and_end_array[0] != start_and_end_array[1]}
   end
 
 end

--- a/app/views/studios/show.html.erb
+++ b/app/views/studios/show.html.erb
@@ -52,8 +52,11 @@
       <%= image_tag image.media.url(:medium)  %>
     <% end %>
   <% end %><br>
-  <%= link_to 'Set Availabilities', studio_availabilities_path(@studio) %><br>
-  <%= link_to 'Add Photos', new_studio_image_path(@studio) %>
+
+  <% if is_studio_owner? %>
+    <%= link_to 'Set Availabilities', studio_availabilities_path(@studio) %><br>
+    <%= link_to 'Add Photos', new_studio_image_path(@studio) %>
+  <% end %>
 
   <script type="text/javascript">
     <% if flash[:errors] %>

--- a/app/views/studios/show.html.erb
+++ b/app/views/studios/show.html.erb
@@ -18,10 +18,9 @@
   <h3>Request Studio Time:</h3>
   <form id="basicExample" action="/studios/<%= @studio.id %>/availabilities/10/bookings" method='POST'>
     <input name="authenticity_token" value="<%= form_authenticity_token %>" type='hidden'>
-    <input type="text" id="start_date" class="date start prevent" name="start_date"/>
-    <input type="text" id="s_time" class="time start prevent" name="s_time"/> to
-    <input type="text" id="end_date" class="date end prevent" name="end_date"/>
-    <input type="text" id="e_time" class="time end prevent" name="e_time"/>
+    <input type="text" id="start_date" class="date start prevent" name="start_date" placeholder='Enter Date'/>
+    <input type="text" id="s_time" class="time start prevent" name="s_time" placeholder='Start Time' /> to
+    <input type="text" id="e_time" class="time end prevent" name="e_time" placeholder="End Time"/>
     <input type="submit" value="Request Studio Time">
   </form>
 
@@ -36,9 +35,6 @@
 
   <div id="rating">
     <%= rating_for @studio  %>
-    <% 25.times do |index| %>
-      <i class="em em-gun">  </i>
-    <% end %>
   </div>
 
   <div id="reviews">
@@ -93,7 +89,7 @@
     $("#basicExample").on('submit', function(e) {
       var startDate = $("#start_date").val();
       var startTime = $("#s_time").val();
-      var endDate = $("#end_date").val();
+      var endDate = $("#start_date").val();
       var endTime = $("#e_time").val();
       var convertedStartTime = moment(startTime, ["h:mm A"]).format("HH:mm");
       var convertedEndTime = moment(endTime, ["h:mm A"]).format("HH:mm");

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -38,7 +38,7 @@ ActiveRecord::Schema.define(version: 20160314183019) do
     t.integer  "availability_id"
     t.datetime "start_time"
     t.datetime "end_time"
-    t.float    "total_price"
+    t.integer  "total_price"
     t.boolean  "confirmed"
     t.datetime "created_at",      null: false
     t.datetime "updated_at",      null: false
@@ -86,17 +86,6 @@ ActiveRecord::Schema.define(version: 20160314183019) do
   end
 
   add_index "rating_caches", ["cacheable_id", "cacheable_type"], name: "index_rating_caches_on_cacheable_id_and_cacheable_type", using: :btree
-
-  create_table "ratings", force: :cascade do |t|
-    t.integer  "ratable_id"
-    t.string   "ratable_type"
-    t.integer  "value"
-    t.integer  "rater_id"
-    t.datetime "created_at",   null: false
-    t.datetime "updated_at",   null: false
-  end
-
-  add_index "ratings", ["ratable_type", "ratable_id"], name: "index_ratings_on_ratable_type_and_ratable_id", using: :btree
 
   create_table "reviews", force: :cascade do |t|
     t.integer  "reviewable_id"


### PR DESCRIPTION
Actually ended up roping a bunch of stuff into this pull:
- Cleaned up the studio time request fields - they now only take one date, auto-calculate the time of the time slot, and pop in an hour late by default.
- Fixed the studio show calendar so it didn't show 0 hour slots, which were happening based on logic from unbooked_times method
- Fixed the availabilities index calendar since it was showing random time blocks for bookings that were only an hour long
- removed links for studio owner
- added route protection for availabilities. 
- Fixed some toastr popups that weren't displaying since they were the wrong flash[] type
